### PR TITLE
Switch to use nodejs env

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a plugin for the [FlowLauncher](https://github.com/Flow-Launcher/Flow.La
 
 ## Installation
 
-To install the plugin, you must have FlowLauncher installed on your system. Once you have FlowLauncher installed, you can download the repository, download the release and place it in the Plugins folder in your FlowLauncher installation directory.
+To install the plugin, you must have Flow Launcher installed on your system, and then install the plugin from the Plugin Store or via `pm install beat how long to beat`. After installation you will be prompted to install/select Node.js if you have not done so.
 
 
 ## Usage

--- a/node.bat
+++ b/node.bat
@@ -1,3 +1,0 @@
-@echo off
-SET plugin_dir=%~dp0%
-node "%plugin_dir%/main.js" %*

--- a/plugin.json
+++ b/plugin.json
@@ -5,8 +5,8 @@
     "Description": "Searches for the provided Name and returns the Playtime from HowLongToBeat",
     "Author": "Tueska",
     "Version": "1.0.0",
-    "Language": "executable",
+    "Language": "JavaScript",
     "Website": "https://github.com/Tueska/fl-howlongtobeat",
-    "ExecuteFileName": "node.bat",
+    "ExecuteFileName": "main.js",
     "IcoPath": "Images\\howlongtobeat.png"
 }


### PR DESCRIPTION
Hi there, this PR will switch the plugin to use Flow's automatic Node.js environment setup. User will be prompted to install/select Node.js, so manual installation will no longer be required.

Tested:
- Installed plugin
- Flow prompts Node.js setup
- Plugin can be used